### PR TITLE
Fixed a bug where the user-entered values would be cleared after automatic currencies update

### DIFF
--- a/lib/ui/screens/home/home_ready.dart
+++ b/lib/ui/screens/home/home_ready.dart
@@ -3,6 +3,7 @@ import 'package:cnvrt/config/routing/routes.dart';
 import 'package:cnvrt/domain/di/providers/currencies/currencies_provider.dart';
 import 'package:cnvrt/domain/di/providers/settings/settings_provider.dart';
 import 'package:cnvrt/l10n/app_localizations.dart';
+import 'package:cnvrt/ui/screens/home/widgets/debug_force_refresh_button.dart';
 import 'package:cnvrt/ui/widgets/currency_inputs_list/currency_inputs_list.dart';
 import 'package:cnvrt/ui/widgets/currency_inputs_list/currency_inputs_list_vm.dart';
 import 'package:cnvrt/utils/logger.dart';
@@ -11,6 +12,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'widgets/current_exchange_rates_info.dart';
+
+final debugShowForceRefresh = false;
 
 class HomeReady extends ConsumerStatefulWidget {
   const HomeReady({super.key});
@@ -98,6 +101,12 @@ class _HomeReadyState extends ConsumerState<HomeReady> {
               ),
             ),
             // const NumericKeyboardGrid(),
+
+            // Debug
+            if (debugShowForceRefresh) ...[
+              SizedBox(height: 20.0),
+              DebugForceRefreshButton(),
+            ],
           ],
         );
       },

--- a/lib/ui/screens/home/widgets/debug_force_refresh_button.dart
+++ b/lib/ui/screens/home/widgets/debug_force_refresh_button.dart
@@ -1,0 +1,22 @@
+import 'package:cnvrt/domain/di/providers/currencies/currencies_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class DebugForceRefreshButton extends ConsumerStatefulWidget {
+  const DebugForceRefreshButton({super.key});
+
+  @override
+  ConsumerState<DebugForceRefreshButton> createState() => _DebugForceRefreshButton();
+}
+class _DebugForceRefreshButton extends ConsumerState<DebugForceRefreshButton> {
+  void triggerForceRefresh() {
+    //ref.read(currenciesProvider.notifier).fetchCurrencies();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(currenciesProvider);
+    
+    return ElevatedButton(onPressed: triggerForceRefresh, child: Text("Force Refresh"));
+  }
+}

--- a/lib/ui/widgets/currency_inputs_list/currency_inputs_list_vm.dart
+++ b/lib/ui/widgets/currency_inputs_list/currency_inputs_list_vm.dart
@@ -14,7 +14,10 @@ class CurrencyInputsListViewModelState {
   final Map<String, TextEditingController> controllers;
   final Map<String, FocusNode> focusNodes;
 
-  const CurrencyInputsListViewModelState({required this.controllers, required this.focusNodes});
+  const CurrencyInputsListViewModelState({
+    required this.controllers,
+    required this.focusNodes,
+  });
 
   @override
   bool operator ==(Object other) =>
@@ -29,23 +32,28 @@ class CurrencyInputsListViewModelState {
 }
 
 final currencyInputsListViewModelProvider =
-    NotifierProvider<CurrencyInputsListViewModel, CurrencyInputsListViewModelState>(() {
+    NotifierProvider<
+      CurrencyInputsListViewModel,
+      CurrencyInputsListViewModelState
+    >(() {
       return CurrencyInputsListViewModel();
     });
 
-class CurrencyInputsListViewModel extends Notifier<CurrencyInputsListViewModelState> {
+class CurrencyInputsListViewModel
+    extends Notifier<CurrencyInputsListViewModelState> {
   final log = Logger('CurrencyInputsListViewModel');
 
   // Cache controllers and focus nodes to prevent focus loss during rebuilds
   final Map<String, TextEditingController> _controllers = {};
   final Map<String, FocusNode> _focusNodes = {};
   bool _onDisposeRegistered = false;
+  bool _isProgrammaticFocus = false;
 
   @override
   CurrencyInputsListViewModelState build() {
     // Watch sortedCurrenciesProvider so this rebuilds when currencies change
     final sortedCurrencies = ref.watch(sortedCurrenciesProvider);
-    
+
     // Register cleanup once
     if (!_onDisposeRegistered) {
       _onDisposeRegistered = true;
@@ -65,7 +73,9 @@ class CurrencyInputsListViewModel extends Notifier<CurrencyInputsListViewModelSt
     final currentSymbols = sortedCurrencies.map((e) => e.symbol).toSet();
 
     // 1. Dispose and remove controllers/nodes for currencies no longer present
-    final symbolsToRemove = _controllers.keys.where((s) => !currentSymbols.contains(s)).toList();
+    final symbolsToRemove = _controllers.keys
+        .where((s) => !currentSymbols.contains(s))
+        .toList();
     for (final symbol in symbolsToRemove) {
       log.d('Disposing controller and focusNode for $symbol');
       _controllers[symbol]?.dispose();
@@ -114,7 +124,12 @@ class CurrencyInputsListViewModel extends Notifier<CurrencyInputsListViewModelSt
       // Use a slight delay to ensure the widget tree is fully built
       Future.delayed(const Duration(milliseconds: 100), () {
         if (focusNode.canRequestFocus && !focusNode.hasFocus) {
+          _isProgrammaticFocus = true;
           focusNode.requestFocus();
+          // Reset the flag after a short delay to allow for normal focus handling
+          Future.delayed(const Duration(milliseconds: 50), () {
+            _isProgrammaticFocus = false;
+          });
         }
       });
     }
@@ -131,7 +146,10 @@ class CurrencyInputsListViewModel extends Notifier<CurrencyInputsListViewModelSt
     final focusedSymbol = ref.read(focusedCurrencyInputSymbolProvider);
     if (focusedSymbol == symbol) return;
 
-    clearAllInputs();
+    // Only clear all inputs if this is not a programmatic focus change
+    if (!_isProgrammaticFocus) {
+      clearAllInputs();
+    }
     ref.read(focusedCurrencyInputSymbolProvider.notifier).setSymbol(symbol);
   }
 
@@ -143,7 +161,11 @@ class CurrencyInputsListViewModel extends Notifier<CurrencyInputsListViewModelSt
     for (var entry in currencyValues.entries) {
       final symbol = entry.key;
       // Use the double value for formatting
-      final value = _formatCurrencyWithSettings(symbol, entry.value, allowDecimalInput);
+      final value = _formatCurrencyWithSettings(
+        symbol,
+        entry.value,
+        allowDecimalInput,
+      );
 
       // Don't update the input field they've typed in
       if (focusedCurrencyInputSymbol == symbol) continue;
@@ -160,11 +182,17 @@ class CurrencyInputsListViewModel extends Notifier<CurrencyInputsListViewModelSt
     }
   }
 
-  String _formatCurrencyWithSettings(String symbol, double value, bool allowDecimalInput) {
+  String _formatCurrencyWithSettings(
+    String symbol,
+    double value,
+    bool allowDecimalInput,
+  ) {
     final formatter = NumberFormat.currency(
       locale: currencyLocales[symbol] ?? 'en_US',
       symbol: '',
-      decimalDigits: allowDecimalInput ? 2 : 0, // Set to 0 for whole numbers, 2 for decimals
+      decimalDigits: allowDecimalInput
+          ? 2
+          : 0, // Set to 0 for whole numbers, 2 for decimals
     );
 
     // Use the actual double value for formatting

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -665,18 +665,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1142,10 +1142,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
Bug:
1. User opens app
2. First saved field is focused
3. User starts entering a numeric value
4. App updates currency data in the background via API
5. App calls `requestFocus` on the first saved field
6. Focus handler clears values as the user is typing

Fix:
- Added a state var to track when a focus request is app or user generated, does not clear fields if it's app generated